### PR TITLE
Remove extra margin classes from sections

### DIFF
--- a/Portfolio_V2/templates/index.html
+++ b/Portfolio_V2/templates/index.html
@@ -888,7 +888,7 @@ and spark curiosity.
 
 <!-- Agent Input Box (initially hidden) -->
 <section id="agent-input-section"
-  class="transition-all duration-500 opacity-0 translate-y-6 pointer-events-none mt-4 relative z-20 flex justify-center items-center px-8">
+  class="transition-all duration-500 opacity-0 translate-y-6 pointer-events-none relative z-20 flex justify-center items-center px-8">
   <div class="w-full max-w-2xl bg-white/5 border border-white/10 backdrop-blur-sm rounded-xl px-4 py-3 shadow-md">
     <div class="flex space-x-4">
       <input
@@ -908,7 +908,7 @@ and spark curiosity.
 
 
 <section id="multi-agent-orchestration"
-  class="mt-4 fade-in-up px-4 md:px-8 pt-10 pb-16 space-y-0 opacity-0 translate-y-10 transition mx-auto duration-700">
+  class="fade-in-up px-4 md:px-8 pt-10 pb-16 space-y-0 opacity-0 translate-y-10 transition mx-auto duration-700">
 
   <h2 class="text-3xl md:text-4xl font-bold text-center mb-8 md:mb-12 mt-16 text-white">
     <span class="text-indigo-400">Distributed AI </span> Workflows


### PR DESCRIPTION
Removed the 'mt-4' class from the agent input and multi-agent orchestration sections to adjust spacing and layout consistency.