### PR TITLE
Add grain overlay background to project pages

### DIFF
--- a/Portfolio_V2/templates/projects/exo-land.html
+++ b/Portfolio_V2/templates/projects/exo-land.html
@@ -14,6 +14,19 @@
   <title>ExoExplorer README</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
+    .grain-overlay {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: -1000;
+  background-image: url("/static/images/grain2.jpg");
+  background-repeat: no-repeat;
+  background-size: cover;  /* Covers entire viewport */
+  background-position: center;
+  mix-blend-mode: overlay;
+  opacity: 0.18;
+}
+
     @keyframes draw-border {
       0% {
         border-width: 0;
@@ -92,6 +105,9 @@
   </style>
 
 </head>
+
+  <div class="grain-overlay pointer-events-none fixed inset-0 z-0"></div>
+
 
 <body class="bg-gradient-to-br from-gray-900 via-slate-800 to-gray-900 text-white min-h-screen">
 

--- a/Portfolio_V2/templates/projects/quote-able.html
+++ b/Portfolio_V2/templates/projects/quote-able.html
@@ -14,6 +14,20 @@
   <title>Octopus Books README</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
+
+    .grain-overlay {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: -1000;
+  background-image: url("/static/images/grain2.jpg");
+  background-repeat: no-repeat;
+  background-size: cover;  /* Covers entire viewport */
+  background-position: center;
+  mix-blend-mode: overlay;
+  opacity: 0.18;
+}
+
     @keyframes draw-border {
       0% {
         border-width: 0;


### PR DESCRIPTION
Introduced a reusable .grain-overlay CSS class and applied it to the ExoExplorer and Octopus Books project pages to enhance visual aesthetics with a subtle grain texture background.