### PR TITLE
Update index.html link structure and cleanup styles

### DIFF
--- a/Portfolio_V2/templates/index.html
+++ b/Portfolio_V2/templates/index.html
@@ -521,7 +521,7 @@ Reading in-between the excel sheets.
     <div id="typewriter-container"
       class="-mt-1 relative flex-1 overflow-y-auto px-4 max-w-xl mx-auto custom-scrollbar text-left">
       <p id="typewriter"
-        class="-mt-1 text-base leading-normal text-grey-900 font-light whitespace-pre-line text-left"></p>
+        class="-mt-1 text-base text-grey-900 font-light whitespace-pre-line text-left"></p>
     </div>
 
     <!-- Typing Indicator -->
@@ -1013,7 +1013,8 @@ and spark curiosity.
       <div class="relative z-10 pt-4 mt-4 md:mt-6 border-t border-white/20 text-xs text-gray-400 font-mono flex justify-between">
         <span>SYS-ID: TEAM-001</span>
 
-        <a href="/blog/marketing-analytics-workflow" 
+        <!-- href="/blog/marketing-analytics-workflow" -->
+        <a
           class="text-gray-400 hover:text-white transition-colors duration-200"
           onclick="event.stopPropagation();">
           [READ_PLAYBOOK]
@@ -1117,7 +1118,8 @@ and spark curiosity.
       <div class="relative z-10 pt-4 mt-4 md:mt-6 border-t border-white/20 text-xs text-gray-400 font-mono flex justify-between">
         <span>SYS-ID: TEAM-002</span>
 
-        <a href="/blog/marketing-analytics-workflow" 
+        <!-- href="/blog/marketing-analytics-workflow" -->
+        <a
           class="text-gray-400 hover:text-white transition-colors duration-200"
           onclick="event.stopPropagation();">
           [READ_PLAYBOOK]
@@ -1212,7 +1214,8 @@ and spark curiosity.
       <div class="relative z-10 pt-4 mt-4 md:mt-6 border-t border-white/20 text-xs text-gray-400 font-mono flex justify-between">
         <span>SYS-ID: TEAM-003</span>
 
-        <a href="/blog/marketing-analytics-workflow" 
+        <!-- href="/blog/marketing-analytics-workflow" -->
+        <a
           class="text-gray-400 hover:text-white transition-colors duration-200"
           onclick="event.stopPropagation();">
           [READ_PLAYBOOK]
@@ -1285,10 +1288,6 @@ and spark curiosity.
   </div>
 </section>
 
-
-
-      
-  
 
   <!-- Contact Card Section -->
   <section


### PR DESCRIPTION
Removed 'leading-normal' class from typewriter paragraph for cleaner styling. Commented out href attributes in playbook links and adjusted their structure to prevent navigation, likely for UI or workflow changes. Also removed unnecessary blank lines for improved readability.