### PR TITLE
Remove typing indicator and adjust typewriter styles

### DIFF
--- a/Portfolio_V2/templates/index.html
+++ b/Portfolio_V2/templates/index.html
@@ -405,12 +405,13 @@
 
 #typewriter {
   color: rgb(243, 244, 246) !important; /* gray-100 */
-  line-height: 1.625 !important; /* leading-relaxed */
+  line-height: 1.325 !important; /* leading-relaxed */
   word-wrap: break-word;
   overflow-wrap: break-word;
   hyphens: auto;
   min-height: 1.5em;
 }
+
 
 </style>
 
@@ -525,13 +526,15 @@ Reading in-between the excel sheets.
     </div>
 
     <!-- Typing Indicator -->
-    <div class="relative h-6 mt-[-4px]">
+    <!-- <div class="relative h-6 mt-[-4px]">
       <div id="typing-indicator" class="absolute top-0 left-0 flex gap-2 hidden">
         <span class="typing-ball dot1"></span>
         <span class="typing-ball dot2"></span>
         <span class="typing-ball dot3"></span>
       </div>
-    </div>
+    </div> -->
+
+
     <!-- Footer Row (polished design) -->
     <div class="relative mt-6">
       <!-- Full-width divider line with a break for the button -->
@@ -840,17 +843,9 @@ and spark curiosity.
     class="-mt-1 relative flex-1 overflow-y-auto px-4 max-w-xl mx-auto custom-scrollbar text-left">
     <p id="agent-typewriter"
       data-agent=""
-      class="-mt-1 text-base leading-tight text-grey-900 font-light whitespace-pre-line text-left"></p>
+      class="-mt-1 text-base leading-normal text-grey-900 font-light whitespace-pre-line text-left"></p>
   </div>
 
-  <!-- Typing Indicator -->
-  <div class="relative h-6 mt-[-4px]">
-    <div id="agent-typing-indicator" class="absolute top-0 left-0 flex gap-2 hidden">
-      <span class="typing-ball dot1"></span>
-      <span class="typing-ball dot2"></span>
-      <span class="typing-ball dot3"></span>
-    </div>
-  </div>
 
   <!-- Footer Row with Plus Button -->
   <div class="relative mt-6">


### PR DESCRIPTION
Commented out the typing indicator elements and updated the line-height for the #typewriter and agent-typewriter classes to improve text appearance. These changes streamline the UI and enhance readability.