### PR TITLE
Update quote text on index page

### DIFF
--- a/Portfolio_V2/templates/index.html
+++ b/Portfolio_V2/templates/index.html
@@ -471,7 +471,7 @@ Building with intention, curiosity, and a quiet fire to explore the unknown.
       <span class="text-white/30">|</span>
       <div class="relative overflow-hidden h-[2.5em] flex items-center">
         <span id="quote-display" class="italic transition-opacity duration-500 ease-in-out">
-Reading in-between the excel sheets.
+Reading in-between the spreadsheets.
         </span>
       </div>
     </div>


### PR DESCRIPTION
Changed 'excel sheets' to 'spreadsheets' in the quote displayed on the index.html page for improved clarity.