### PR TITLE
Improve footer responsiveness for small screens

### DIFF
--- a/Portfolio_V2/templates/index.html
+++ b/Portfolio_V2/templates/index.html
@@ -945,6 +945,8 @@ and spark curiosity.
                 leading-snug whitespace-pre-line"></p>
     </div>
 
+
+
     <!-- Footer -->
     <div class="relative mt-6">
       <div class="absolute inset-0 flex items-center justify-center">
@@ -955,12 +957,15 @@ and spark curiosity.
 
       <div class="relative z-20 flex items-center justify-between
                   text-xs text-gray-400 font-mono px-4 pt-6">
-        <span class="hidden sm:inline">BUSINESS-CARD-079</span>
+        <span>
+          <span class="inline sm:hidden">CARD-079</span>
+          <span class="hidden sm:inline">BUSINESS-CARD-079</span>
+        </span>
 
         <!-- Chat button toggles the agent input -->
         <button id="agent-chat-btn" type="button"
                 class="absolute left-1/2 -translate-x-1/2 top-0
-                       -translate-y-2 sm:translate-y-0
+                       sm:translate-y-0
                        bg-transparent text-white rounded-full w-10 h-10
                        flex items-center justify-center shadow-md
                        border border-white/20 hover:scale-105
@@ -973,7 +978,10 @@ and spark curiosity.
           </svg>
         </button>
 
-        <span class="hidden sm:inline">SECTOR:&nbsp;DATA&nbsp;OPS</span>
+          <span>
+          <span class="inline sm:hidden">DATA-OPS</span>
+          <span class="hidden sm:inline">SECTOR:&nbsp;DATA&nbsp;OPS</span>
+        </span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Updated the footer to display shorter labels ('CARD-079' and 'DATA-OPS') on small screens and full labels on larger screens, enhancing mobile usability and layout.