### PR TITLE
Adjust margin for transition sections in index.html

### DIFF
--- a/Portfolio_V2/templates/index.html
+++ b/Portfolio_V2/templates/index.html
@@ -741,7 +741,7 @@ Reading in-between the spreadsheets
   opacity-0 
   translate-y-6 
   pointer-events-none 
-  mt-4 
+  mt-0
   relative 
   z-20 
   flex 
@@ -1122,7 +1122,7 @@ and spark curiosity.
 </section>
 
 <section id="agent-input-section"
-  class="transition-all duration-500 opacity-0 translate-y-6 pointer-events-none mt-4 relative z-20 flex justify-center items-center px-8">
+  class="transition-all duration-500 opacity-0 translate-y-6 pointer-events-none relative z-20 flex justify-center items-center px-8">
   <div
     class="w-full max-w-2xl bg-white/10 backdrop-blur-xl border border-white/30 rounded-2xl px-4 py-3 shadow-2xl"
     style="border-color:rgba(255,255,255,0.9);


### PR DESCRIPTION
Changed 'mt-4' to 'mt-0' and removed 'mt-4' from specific sections to refine vertical spacing and layout consistency in the template.