### PR TITLE
Reduce size of animated circle elements

### DIFF
--- a/Portfolio_V2/templates/index.html
+++ b/Portfolio_V2/templates/index.html
@@ -426,8 +426,8 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 150px;
-  height: 150px;
+  width: 130px;
+  height: 130px;
   transform: translate(-50%, -50%);
   pointer-events: none;
   z-index: 100;
@@ -466,8 +466,8 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 150px;
-  height: 150px;
+  width: 130px;
+  height: 130px;
   transform: translate(-50%, -50%);
   pointer-events: none;
   z-index: -1;


### PR DESCRIPTION
Decreased the width and height of two absolutely positioned circle elements from 150px to 130px in index.html for improved layout and visual balance.